### PR TITLE
In 06: Gebruik SDL ipv WinAPI tbv cross-platform werken

### DIFF
--- a/06-template/main.cpp
+++ b/06-template/main.cpp
@@ -19,5 +19,5 @@ int main(int argc, char **argv){
    circle ball( w, 70, 30, 20 );
    ball.print();
    
-   return 0;
+   w.mainloop();
 }

--- a/06-template/window.cpp
+++ b/06-template/window.cpp
@@ -61,7 +61,12 @@ void window::clear(){
 }
 
 void window::draw(int x, int y){
-    if ((size_t)y < pixels.size() && (size_t)x < pixels[y].size())
+    if (
+           y >= 0
+        && x >= 0
+        && (size_t)y < pixels.size()
+        && (size_t)x < pixels[y].size()
+    )
         pixels[y][x] = true;
 }
 

--- a/06-template/window.cpp
+++ b/06-template/window.cpp
@@ -61,8 +61,8 @@ void window::clear(){
 }
 
 void window::draw(int x, int y){
-    pixels[y][x] = true;
-    // put_pixel(sdl_renderer, x, y, scale);
+    if (y < pixels.size() && x < pixels[y].size())
+        pixels[y][x] = true;
 }
 
 void window::redraw() {

--- a/06-template/window.cpp
+++ b/06-template/window.cpp
@@ -33,7 +33,8 @@ window::window(int x_size, int y_size, int scale):
     sdl_renderer = SDL_CreateRenderer(
         sdl_win,
         -1,
-        (SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC)
+        0 // Renderer flags. With 0 SDL should use acceleration when
+          // available and fall back to software rendering otherwise.
     );
 
     if (!sdl_renderer)

--- a/06-template/window.cpp
+++ b/06-template/window.cpp
@@ -61,7 +61,7 @@ void window::clear(){
 }
 
 void window::draw(int x, int y){
-    if (y < pixels.size() && x < pixels[y].size())
+    if ((size_t)y < pixels.size() && (size_t)x < pixels[y].size())
         pixels[y][x] = true;
 }
 

--- a/06-template/window.hpp
+++ b/06-template/window.hpp
@@ -4,20 +4,25 @@
 #ifndef WINDOW_HPP
 #define WINDOW_HPP
 
-#include "windows.h"
+#include <SDL2/SDL.h>
+#include <vector>
 
 class window {
-   int x_size;
-   int y_size;
-   int scale;
+    int x_size;
+    int y_size;
+    int scale;
    
-   // needed to use the OS window
-   HDC hdc;
+    SDL_Window   *sdl_win;
+    SDL_Renderer *sdl_renderer;
+
+    std::vector< std::vector<bool> > pixels;
    
 public:
-   window( int x_size, int y_size, int scale );
-   void draw( int x, int y );
-   void clear();
+    window(int x_size, int y_size, int scale);
+    void draw(int x, int y);
+    void clear();
+    void redraw();
+    void mainloop();
 };
 
 #endif // WINDOW_HPP

--- a/bmptk-mef.py
+++ b/bmptk-mef.py
@@ -418,7 +418,7 @@ def codelite_project_template_mingw():
       <Compiler Options="-g;-O0;-std=c++11" C_Options="-g;-O0;-Wall" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="0">
         <IncludePath Value=".;../Catch/include"/>
       </Compiler>
-      <Linker Options="-lgdi32" Required="yes"/>
+      <Linker Options="-lSDL2" Required="yes"/>
       <ResourceCompiler Options="" Required="no"/>
       <General OutputFile="$(IntermediateDirectory)/$(ProjectName)" IntermediateDirectory="./Debug" Command="./$(ProjectName)" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="$(IntermediateDirectory)" PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
       <Environment EnvVarSetName="&lt;Use Defaults&gt;" DbgSetName="&lt;Use Defaults&gt;">


### PR DESCRIPTION
Dit lost #1 op, en zorgt er daarmee voor dat studenten niet alleen op Windows hun opdrachten kunnen maken.

SDL2 is een cross-platform library voor onder andere graphics. Het werkt op Windows, Linux, OS X, en meer.

Naast het gebruikmaken van SDL objecten in plaats van Windows-specifieke window handles etc. heb ik een mainloop gemaakt zodat het venster netjes opnieuw wordt getekend bij o.a. verplaatsen en zodat het programma kan reageren op events (`q` sluit het programma).

Afgezien van de `mainloop()` toevoeging heb ik heb de publieke interface van `window` niet aangepast, dit maakt het makkelijk om de twee `window` implementaties om te wisselen.

Als deze wijziging geaccordeerd wordt (ook al wordt hij niet gemerged) zal ik voor toekomstige opdrachten vergelijkbare aanpassingen maken zodat ze ook op mijn machine (en die van alle medestudenten) werken.
