### PR TITLE
Fixed the terrible line code

### DIFF
--- a/06-template/line.cpp
+++ b/06-template/line.cpp
@@ -1,75 +1,27 @@
 // example:
-// definition of the functions of a line class 
+// definition of the functions of a line class
 // you are not expected to understand how line::print works
 
 #include "line.hpp"
 
-// avoid these because <algorithm> imports iostream stuff
-template <class T> void swap( T& a, T& b ){
-  T c(a); a=b; b=c;
-}
+void line::print()
+{
 
-void line::print(){
-    
-   const int width = 1; 
-              
-   // http://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm
-   // http://homepages.enterprise.net/murphy/thickline/index.html
-   
-   // int i0 = 0; int i1 = 1;
-   int i0 = - ( width / 2 ); 
-   // int i1 = 1;
-   int i1 = width + i0;
-   // i1 = width;
-   
-   int x0 = start_x;
-   int y0 = start_y;
-   int x1 = end_x;
-   int y1 = end_y;
-   int Dx = x1 - x0; 
-   int Dy = y1 - y0;
-   int steep = (abs(Dy) >= abs(Dx));
-   int ox = 0, oy = 1;
-   if( steep ){
-      swap(x0, y0);
-      swap(x1, y1);
-      // recompute Dx, Dy after swap
-      Dx = x1 - x0;
-      Dy = y1 - y0;
-      swap( ox, oy );
-   }
-   int xstep = 1;
-   if( Dx < 0 ){
-      xstep = -1;
-      Dx = -Dx;
-   }
-   int ystep = 1;
-   if( Dy < 0 ){
-      ystep = -1;    
-      Dy = -Dy; 
-   }
-   int TwoDy = 2*Dy; 
-   int TwoDyTwoDx = TwoDy - 2*Dx; // 2*Dy - 2*Dx
-   int E = TwoDy - Dx; //2*Dy - Dx
-   int y = y0;
-   int xDraw, yDraw;  
-   for( int x = x0; x != x1; x += xstep ){    
-      if (steep) {     
-         xDraw = y;
-         yDraw = x;
-      } else {     
-         xDraw = x;
-         yDraw = y;
-      }
-      for( int i = i0; i < i1; i++ ){
-         w.draw( xDraw + ox * i, yDraw + oy * i );
-      }   
-      // trace << xDraw << " " << yDraw;
-      if( E > 0 ){
-         E += TwoDyTwoDx; //E += 2*Dy - 2*Dx;
-         y = y + ystep;
-      } else {
-         E += TwoDy; //E += 2*Dy;
-      }
-   }
+	int dx = abs(x1-x0), sx = x0<x1 ? 1 : -1;
+	int dy = abs(y1-y0), sy = y0<y1 ? 1 : -1;
+	int err = (dx>dy ? dx : -dy)/2, e2;
+
+	for(;;) {
+		w.draw(x0,y0);
+		if (x0==x1 && y0==y1) break;
+		e2 = err;
+		if (e2 >-dx) {
+			err -= dy;
+			x0 += sx;
+		}
+		if (e2 < dy) {
+			err += dx;
+			y0 += sy;
+		}
+	}
 }

--- a/06-template/line.cpp
+++ b/06-template/line.cpp
@@ -6,7 +6,8 @@
 
 void line::print()
 {
-
+	int x0 = start_x, y0 = start_y;
+	int x1 = end_x, y1 = end_y;
 	int dx = abs(x1-x0), sx = x0<x1 ? 1 : -1;
 	int dy = abs(y1-y0), sy = y0<y1 ? 1 : -1;
 	int err = (dx>dy ? dx : -dy)/2, e2;

--- a/06-template/line.hpp
+++ b/06-template/line.hpp
@@ -12,17 +12,17 @@
 
 class line {
 private:
-   int start_x;
-   int start_y; 
-   int end_x;
-   int end_y;
+   int x0;
+   int y0; 
+   int x1;
+   int y1;
    window & w;
 public:
    line( window & w, int start_x, int start_y, int end_x, int end_y ):
-      start_x( start_x ),
-      start_y( start_y ),
-      end_x( end_x ),
-      end_y( end_y ),
+      x0( start_x ),
+      y0( start_y ),
+      x1( end_x ),
+      y1( end_y ),
       w( w )
    {}
    void print();

--- a/06-template/line.hpp
+++ b/06-template/line.hpp
@@ -12,17 +12,17 @@
 
 class line {
 private:
-   int x0;
-   int y0; 
-   int x1;
-   int y1;
+   int start_x;
+   int start_y; 
+   int end_x;
+   int end_y;
    window & w;
 public:
    line( window & w, int start_x, int start_y, int end_x, int end_y ):
-      x0( start_x ),
-      y0( start_y ),
-      x1( end_x ),
-      y1( end_y ),
+      start_x( start_x ),
+      start_y( start_y ),
+      end_x( end_x ),
+      end_y( end_y ),
       w( w )
    {}
    void print();


### PR DESCRIPTION
I fixed the code for lines, witch had a couple of issues
1. A line from (0,0) to (10,0) only produced a line from (0,0) to (0,9) this is why there are missing pixels in the rectangle.
2. It makes the code much more readable and compact, the old line code was very, very ugly

This commit fixes all of the problems named above.

Only the line.cpp and line.hpp were changed, the way you declare a line is still the same
You can still use and interact with lines in exactly the same way as before, only they now just work! Merging with this code should not break any code that was written using the old lines.

Here is a quick before and after picture:

Before:
![old](https://cloud.githubusercontent.com/assets/3768010/14498812/3b9cdc52-019c-11e6-8ca7-8fc6e39ec42f.jpg)

After:
![new](https://cloud.githubusercontent.com/assets/3768010/14498757/fcff3ec2-019b-11e6-9bd2-c3fca8b884d1.jpg)
